### PR TITLE
List Dependents With Stars and Forks Counts

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -21,7 +21,7 @@ yargs(hideBin(process.argv))
       try {
         const dependents = await fetchDependents(argv.repo);
         for (const dependent of dependents) {
-          process.stdout.write((dependent ?? "null") + "\n");
+          process.stdout.write((dependent.repo ?? "null") + "\n");
         }
       } catch (err) {
         process.stdout.write(`${err}\n`);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -21,7 +21,24 @@ yargs(hideBin(process.argv))
       try {
         const dependents = await fetchDependents(argv.repo);
         for (const dependent of dependents) {
-          process.stdout.write((dependent.repo ?? "null") + "\n");
+          const repo: string = dependent.repo ?? "null";
+          if (repo.length > 32) {
+            process.stdout.write(`${repo.substring(0, 29)}...`);
+          } else {
+            process.stdout.write(repo.padEnd(32));
+          }
+
+          if (dependent.forks !== null) {
+            const forks = dependent.forks.toString();
+            process.stdout.write(`  ${forks.padStart(3)} forks`);
+          }
+
+          if (dependent.stars !== null) {
+            const stars = dependent.stars.toString();
+            process.stdout.write(`  ${stars.padStart(3)} stars`);
+          }
+
+          process.stdout.write("\n");
         }
       } catch (err) {
         process.stdout.write(`${err}\n`);

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,4 +1,4 @@
-import { parseDependentsFromHtml } from "./parse.js";
+import { Dependent, parseDependentsFromHtml } from "./parse.js";
 
 /**
  * Fetches the dependent repositories of a given repository.
@@ -7,9 +7,7 @@ import { parseDependentsFromHtml } from "./parse.js";
  * @returns A promise that resolves to a list of dependent repositories.
  * @throws An error if the fetch operation fails.
  */
-export async function fetchDependents(
-  repo: string,
-): Promise<(string | null)[]> {
+export async function fetchDependents(repo: string): Promise<Dependent[]> {
   const res = await fetch(`https://github.com/${repo}/network/dependents`);
   if (res.status !== 200) {
     throw new Error(`Failed to fetch ${repo}: ${res.status}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { fetchDependents } from "./fetch.js";
+export { Dependent, parseDependentsFromHtml } from "./parse.js";

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -29,7 +29,7 @@ it("should parse dependents from HTML data", () => {
     ].join("\n"),
   );
 
-  expect(dependents).toEqual(["foo/bar", "foo/baz"]);
+  expect(dependents).toEqual([{ repo: "foo/bar" }, { repo: "foo/baz" }]);
 });
 
 it("should parse dependents from HTML data without details", () => {
@@ -60,7 +60,7 @@ it("should parse dependents from HTML data without details", () => {
     ].join("\n"),
   );
 
-  expect(dependents).toEqual(["foo/bar", "foo/baz"]);
+  expect(dependents).toEqual([{ repo: "foo/bar" }, { repo: "foo/baz" }]);
 });
 
 it("should fail to parse dependents from an invalid HTML data", () => {

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -15,12 +15,18 @@ it("should parse dependents from HTML data", () => {
       `      <div>`,
       `        <img></img>`,
       `        <span><a>foo</a>/<a>bar</a><small></small></span>`,
-      `        <div></div>`,
+      `        <div>`,
+      `          <span><svg></svg>11</span>`,
+      `          <span><svg></svg>13</span>`,
+      `        </div>`,
       `      </div>`,
       `      <div>`,
       `        <img></img>`,
       `        <span><a>foo</a>/<a>baz</a><small></small></span>`,
-      `        <div></div>`,
+      `        <div>`,
+      `          <span><svg></svg>13</span>`,
+      `          <span><svg></svg>17</span>`,
+      `        </div>`,
       `      </div>`,
       `    </div>`,
       `    <div></div>`,
@@ -29,7 +35,10 @@ it("should parse dependents from HTML data", () => {
     ].join("\n"),
   );
 
-  expect(dependents).toEqual([{ repo: "foo/bar" }, { repo: "foo/baz" }]);
+  expect(dependents).toEqual([
+    { repo: "foo/bar", stars: 11, forks: 13 },
+    { repo: "foo/baz", stars: 13, forks: 17 },
+  ]);
 });
 
 it("should parse dependents from HTML data without details", () => {
@@ -46,12 +55,18 @@ it("should parse dependents from HTML data without details", () => {
       `      <div>`,
       `        <img></img>`,
       `        <span><a>foo</a>/<a>bar</a><small></small></span>`,
-      `        <div></div>`,
+      `        <div>`,
+      `          <span><svg></svg>11</span>`,
+      `          <span><svg></svg>13</span>`,
+      `        </div>`,
       `      </div>`,
       `      <div>`,
       `        <img></img>`,
       `        <span><a>foo</a>/<a>baz</a><small></small></span>`,
-      `        <div></div>`,
+      `        <div>`,
+      `          <span><svg></svg>13</span>`,
+      `          <span><svg></svg>17</span>`,
+      `        </div>`,
       `      </div>`,
       `    </div>`,
       `    <div></div>`,
@@ -60,7 +75,10 @@ it("should parse dependents from HTML data without details", () => {
     ].join("\n"),
   );
 
-  expect(dependents).toEqual([{ repo: "foo/bar" }, { repo: "foo/baz" }]);
+  expect(dependents).toEqual([
+    { repo: "foo/bar", stars: 11, forks: 13 },
+    { repo: "foo/baz", stars: 13, forks: 17 },
+  ]);
 });
 
 it("should fail to parse dependents from an invalid HTML data", () => {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -2,6 +2,8 @@ import { JSDOM } from "jsdom";
 
 export interface Dependent {
   repo: string | null;
+  stars: number | null;
+  forks: number | null;
 }
 
 /**
@@ -21,6 +23,8 @@ export function parseDependentsFromHtml(html: string): Dependent[] {
       for (let i = 1; i < box.children.length; ++i) {
         const dependent: Dependent = {
           repo: null,
+          stars: null,
+          forks: null,
         };
 
         const row = box.children.item(i);
@@ -33,6 +37,19 @@ export function parseDependentsFromHtml(html: string): Dependent[] {
             dependent.repo += "/";
             const repository = span.children.item(1);
             if (repository !== null) dependent.repo += repository.textContent;
+          }
+
+          const div = row.children.item(2);
+          if (div !== null) {
+            const starsSpan = div.children.item(0);
+            if (starsSpan !== null && starsSpan.textContent !== null) {
+              dependent.stars = Number.parseInt(starsSpan.textContent);
+            }
+
+            const forksSpan = div.children.item(1);
+            if (forksSpan !== null && forksSpan.textContent !== null) {
+              dependent.forks = Number.parseInt(forksSpan.textContent);
+            }
           }
         }
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,32 +1,38 @@
 import { JSDOM } from "jsdom";
 
+export interface Dependent {
+  repo: string | null;
+}
+
 /**
  * Parses the dependent repositories from HTML data.
  *
  * @param html - The HTML data.
  * @returns A promise that resolves to a list of dependent repositories.
  */
-export function parseDependentsFromHtml(html: string): (string | null)[] {
+export function parseDependentsFromHtml(html: string): Dependent[] {
   const dom = new JSDOM(html);
   const div = dom.window.document.getElementById("dependents");
   if (div !== null) {
     const box = div.children.item(div.children.length - 2);
     if (box !== null) {
-      const dependents: (string | null)[] = [];
+      const dependents: Dependent[] = [];
 
       for (let i = 1; i < box.children.length; ++i) {
-        let dependent: string | null = null;
+        const dependent: Dependent = {
+          repo: null,
+        };
 
         const row = box.children.item(i);
         if (row !== null) {
-          dependent = "";
+          dependent.repo = "";
           const span = row.children.item(1);
           if (span !== null) {
             const user = span.children.item(0);
-            if (user !== null) dependent += user.textContent;
-            dependent += "/";
+            if (user !== null) dependent.repo += user.textContent;
+            dependent.repo += "/";
             const repository = span.children.item(1);
-            if (repository !== null) dependent += repository.textContent;
+            if (repository !== null) dependent.repo += repository.textContent;
           }
         }
 


### PR DESCRIPTION
This pull request resolves #9 by updating `parseDependentsFromHtml` to return a list of `Dependent` objects, which contain dependent repositories, stars, and forks. It also updates the binary script to list dependent stars and forks alongside their repositories.