### PR TITLE
Catch Error on Failure in Binary Script

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -18,8 +18,13 @@ yargs(hideBin(process.argv))
         type: "string",
       }),
     async (argv) => {
-      const dependents = await fetchDependents(argv.repo);
-      process.stdout.write(dependents.join("\n") + "\n");
+      try {
+        const dependents = await fetchDependents(argv.repo);
+        process.stdout.write(dependents.join("\n") + "\n");
+      } catch (err) {
+        process.stdout.write(`${err}\n`);
+        process.exitCode = 1;
+      }
     },
   )
   .parse();


### PR DESCRIPTION
This pull request resolves #11 by modifying the `src/bin.ts` file to catch errors when fetching dependents, outputting a clean error message while ensuring the process exits with a non-zero status code.