### PR TITLE
Fix Invalid Child Index When Parsing Dependents From HTML

### DIFF
--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -23,6 +23,38 @@ it("should parse dependents from HTML data", () => {
       `        <div></div>`,
       `      </div>`,
       `    </div>`,
+      `    <div></div>`,
+      `  </div>`,
+      `</body>`,
+    ].join("\n"),
+  );
+
+  expect(dependents).toEqual(["foo/bar", "foo/baz"]);
+});
+
+it("should parse dependents from HTML data without details", () => {
+  const dependents = parseDependentsFromHtml(
+    [
+      `<!DOCTYPE html>`,
+      `<body>`,
+      `  <div id="dependents">`,
+      `    <div class="Subhead"></div>`,
+      `    <nav class="tabnav d-flex"></nav>`,
+      `    <p></p>`,
+      `    <div>`,
+      `      <div></div>`,
+      `      <div>`,
+      `        <img></img>`,
+      `        <span><a>foo</a>/<a>bar</a><small></small></span>`,
+      `        <div></div>`,
+      `      </div>`,
+      `      <div>`,
+      `        <img></img>`,
+      `        <span><a>foo</a>/<a>baz</a><small></small></span>`,
+      `        <div></div>`,
+      `      </div>`,
+      `    </div>`,
+      `    <div></div>`,
       `  </div>`,
       `</body>`,
     ].join("\n"),

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -12,7 +12,7 @@ export function parseDependentsFromHtml(html: string): string[] {
 
   const div = dom.window.document.getElementById("dependents");
   if (div !== null) {
-    const box = div.children.item(4);
+    const box = div.children.item(div.children.length - 2);
     if (box !== null) {
       for (let i = 1; i < box.children.length; ++i) {
         const row = box.children.item(i);


### PR DESCRIPTION
This pull request resolves #13 by fixing the invalid box element index when parsing dependents from HTML, whether it contains a details element or not.