### PR TITLE
Separate HTML Parsing from Fetch Dependents Function

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,7 +2,7 @@
 
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { fetchDependents } from "./dependents.js";
+import { fetchDependents } from "./fetch.js";
 
 yargs(hideBin(process.argv))
   .scriptName("github-dependents")

--- a/src/fetch.test.ts
+++ b/src/fetch.test.ts
@@ -1,11 +1,8 @@
-import { fetchDependents } from "./dependents.js";
+import { fetchDependents } from "./fetch.js";
 
 it("should fetch dependents of a repository", async () => {
   const dependents = await fetchDependents("threeal/setup-yarn-action");
   expect(dependents.length).toBeGreaterThan(0);
-  for (const dependent of dependents) {
-    expect(dependent).toMatch(/.+\/.+/);
-  }
 });
 
 it("should fail to fetch dependents of an invalid repository", async () => {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,0 +1,17 @@
+import { parseDependentsFromHtml } from "./parse.js";
+
+/**
+ * Fetches the dependent repositories of a given repository.
+ *
+ * @param repo - The full name of the repository in the format `user/repository`.
+ * @returns A promise that resolves to a list of dependent repositories.
+ * @throws An error if the fetch operation fails.
+ */
+export async function fetchDependents(repo: string): Promise<string[]> {
+  const res = await fetch(`https://github.com/${repo}/network/dependents`);
+  if (res.status !== 200) {
+    throw new Error(`Failed to fetch ${repo}: ${res.status}`);
+  }
+
+  return parseDependentsFromHtml(await res.text());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { fetchDependents } from "./dependents.js";
+export { fetchDependents } from "./fetch.js";

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -1,0 +1,32 @@
+import { parseDependentsFromHtml } from "./parse.js";
+
+it("should parse dependents from HTML data", () => {
+  const dependents = parseDependentsFromHtml(
+    [
+      `<!DOCTYPE html>`,
+      `<body>`,
+      `  <div id="dependents">`,
+      `    <div></div>`,
+      `    <nav></nav>`,
+      `    <details></details>`,
+      `    <p></p>`,
+      `    <div>`,
+      `      <div></div>`,
+      `      <div>`,
+      `        <img></img>`,
+      `        <span><a>foo</a>/<a>bar</a><small></small></span>`,
+      `        <div></div>`,
+      `      </div>`,
+      `      <div>`,
+      `        <img></img>`,
+      `        <span><a>foo</a>/<a>baz</a><small></small></span>`,
+      `        <div></div>`,
+      `      </div>`,
+      `    </div>`,
+      `  </div>`,
+      `</body>`,
+    ].join("\n"),
+  );
+
+  expect(dependents).toEqual(["foo/bar", "foo/baz"]);
+});

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,19 +1,13 @@
 import { JSDOM } from "jsdom";
 
 /**
- * Fetches the dependent repositories of a given repository.
+ * Parses the dependent repositories from HTML data.
  *
- * @param repo - The full name of the repository in the format `user/repository`.
+ * @param html - The HTML data.
  * @returns A promise that resolves to a list of dependent repositories.
- * @throws An error if the fetch operation fails.
  */
-export async function fetchDependents(repo: string): Promise<string[]> {
-  const res = await fetch(`https://github.com/${repo}/network/dependents`);
-  if (res.status !== 200) {
-    throw new Error(`Failed to fetch ${repo}: ${res.status}`);
-  }
-
-  const dom = new JSDOM(await res.text());
+export function parseDependentsFromHtml(html: string): string[] {
+  const dom = new JSDOM(html);
   const dependents: string[] = [];
 
   const div = dom.window.document.getElementById("dependents");


### PR DESCRIPTION
This pull request resolves #15 by separating the `src/dependents.ts` file into `fetch.ts` and `parse.ts` files, improving file organization and allowing the HTML parsing part to be tested independently from the fetching process.