### PR TITLE
Throw Error On Invalid HTML When Parsing Dependents

### DIFF
--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -62,3 +62,11 @@ it("should parse dependents from HTML data without details", () => {
 
   expect(dependents).toEqual(["foo/bar", "foo/baz"]);
 });
+
+it("should fail to parse dependents from an invalid HTML data", () => {
+  expect(() =>
+    parseDependentsFromHtml(
+      [`<!DOCTYPE html>`, `<body>`, `</body>`].join("\n"),
+    ),
+  ).toThrow("invalid HTML format");
+});

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -29,8 +29,10 @@ export function parseDependentsFromHtml(html: string): string[] {
           dependents.push(dependent);
         }
       }
+
+      return dependents;
     }
   }
 
-  return dependents;
+  throw new Error("invalid HTML format");
 }


### PR DESCRIPTION
This pull request resolves #17 by modifying the `parseDependentsFromHtml` function to throw an error when provided with invalid HTML data for parsing dependents. It also updates the test accordingly.