### PR TITLE
Allow Returning Null Dependents

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -20,7 +20,9 @@ yargs(hideBin(process.argv))
     async (argv) => {
       try {
         const dependents = await fetchDependents(argv.repo);
-        process.stdout.write(dependents.join("\n") + "\n");
+        for (const dependent of dependents) {
+          process.stdout.write((dependent ?? "null") + "\n");
+        }
       } catch (err) {
         process.stdout.write(`${err}\n`);
         process.exitCode = 1;

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -7,7 +7,9 @@ import { parseDependentsFromHtml } from "./parse.js";
  * @returns A promise that resolves to a list of dependent repositories.
  * @throws An error if the fetch operation fails.
  */
-export async function fetchDependents(repo: string): Promise<string[]> {
+export async function fetchDependents(
+  repo: string,
+): Promise<(string | null)[]> {
   const res = await fetch(`https://github.com/${repo}/network/dependents`);
   if (res.status !== 200) {
     throw new Error(`Failed to fetch ${repo}: ${res.status}`);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,18 +6,20 @@ import { JSDOM } from "jsdom";
  * @param html - The HTML data.
  * @returns A promise that resolves to a list of dependent repositories.
  */
-export function parseDependentsFromHtml(html: string): string[] {
+export function parseDependentsFromHtml(html: string): (string | null)[] {
   const dom = new JSDOM(html);
-  const dependents: string[] = [];
-
   const div = dom.window.document.getElementById("dependents");
   if (div !== null) {
     const box = div.children.item(div.children.length - 2);
     if (box !== null) {
+      const dependents: (string | null)[] = [];
+
       for (let i = 1; i < box.children.length; ++i) {
+        let dependent: string | null = null;
+
         const row = box.children.item(i);
         if (row !== null) {
-          let dependent = "";
+          dependent = "";
           const span = row.children.item(1);
           if (span !== null) {
             const user = span.children.item(0);
@@ -26,8 +28,9 @@ export function parseDependentsFromHtml(html: string): string[] {
             const repository = span.children.item(1);
             if (repository !== null) dependent += repository.textContent;
           }
-          dependents.push(dependent);
         }
+
+        dependents.push(dependent);
       }
 
       return dependents;


### PR DESCRIPTION
This pull request resolves #19 by updating the `parseDependentsFromHtml` function to allow it to return `null` for dependents, indicating that a dependent entry exists but has missing information.