### PR TITLE
Fetch Dependents From Subsequent Pages

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -8,11 +8,19 @@ import { Dependent, parseDependentsFromHtml } from "./parse.js";
  * @throws An error if the fetch operation fails.
  */
 export async function fetchDependents(repo: string): Promise<Dependent[]> {
-  const res = await fetch(`https://github.com/${repo}/network/dependents`);
-  if (res.status !== 200) {
-    throw new Error(`Failed to fetch ${repo}: ${res.status}`);
+  const allDependents: Dependent[] = [];
+  let url: string | null = `https://github.com/${repo}/network/dependents`;
+
+  while (url !== null) {
+    const res = await fetch(url);
+    if (res.status !== 200) {
+      throw new Error(`Failed to fetch ${repo}: ${res.status}`);
+    }
+
+    const { dependents, nextPage } = parseDependentsFromHtml(await res.text());
+    allDependents.push(...dependents);
+    url = nextPage;
   }
 
-  const { dependents } = parseDependentsFromHtml(await res.text());
-  return dependents;
+  return allDependents;
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -13,5 +13,6 @@ export async function fetchDependents(repo: string): Promise<Dependent[]> {
     throw new Error(`Failed to fetch ${repo}: ${res.status}`);
   }
 
-  return parseDependentsFromHtml(await res.text());
+  const { dependents } = parseDependentsFromHtml(await res.text());
+  return dependents;
 }

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -25,16 +25,26 @@ it("should parse dependents from HTML data", () => {
       `        </div>`,
       `      </div>`,
       `    </div>`,
-      `    <div></div>`,
+      `    <div>`,
+      `      <div>`,
+      `        ::before`,
+      `        <button></button>`,
+      `        <a href="an-url">hello</a>`,
+      `        ::after`,
+      `      </div>`,
+      `    </div>`,
       `  </div>`,
       `</body>`,
     ].join("\n"),
   );
 
-  expect(dependents).toEqual([
-    { repo: "foo/bar", stars: 11, forks: 13 },
-    { repo: "foo/baz", stars: 13, forks: 17 },
-  ]);
+  expect(dependents).toEqual({
+    dependents: [
+      { repo: "foo/bar", stars: 11, forks: 13 },
+      { repo: "foo/baz", stars: 13, forks: 17 },
+    ],
+    nextPage: "an-url",
+  });
 });
 
 it("should fail to parse dependents from an invalid HTML data", () => {

--- a/src/parse.test.ts
+++ b/src/parse.test.ts
@@ -6,50 +6,6 @@ it("should parse dependents from HTML data", () => {
       `<!DOCTYPE html>`,
       `<body>`,
       `  <div id="dependents">`,
-      `    <div></div>`,
-      `    <nav></nav>`,
-      `    <details></details>`,
-      `    <p></p>`,
-      `    <div>`,
-      `      <div></div>`,
-      `      <div>`,
-      `        <img></img>`,
-      `        <span><a>foo</a>/<a>bar</a><small></small></span>`,
-      `        <div>`,
-      `          <span><svg></svg>11</span>`,
-      `          <span><svg></svg>13</span>`,
-      `        </div>`,
-      `      </div>`,
-      `      <div>`,
-      `        <img></img>`,
-      `        <span><a>foo</a>/<a>baz</a><small></small></span>`,
-      `        <div>`,
-      `          <span><svg></svg>13</span>`,
-      `          <span><svg></svg>17</span>`,
-      `        </div>`,
-      `      </div>`,
-      `    </div>`,
-      `    <div></div>`,
-      `  </div>`,
-      `</body>`,
-    ].join("\n"),
-  );
-
-  expect(dependents).toEqual([
-    { repo: "foo/bar", stars: 11, forks: 13 },
-    { repo: "foo/baz", stars: 13, forks: 17 },
-  ]);
-});
-
-it("should parse dependents from HTML data without details", () => {
-  const dependents = parseDependentsFromHtml(
-    [
-      `<!DOCTYPE html>`,
-      `<body>`,
-      `  <div id="dependents">`,
-      `    <div class="Subhead"></div>`,
-      `    <nav class="tabnav d-flex"></nav>`,
-      `    <p></p>`,
       `    <div>`,
       `      <div></div>`,
       `      <div>`,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -10,55 +10,67 @@ export interface Dependent {
  * Parses the dependent repositories from HTML data.
  *
  * @param html - The HTML data.
- * @returns A promise that resolves to a list of dependent repositories.
+ * @returns A promise that resolves to an object containing a list of dependent
+ * repositories and the URL of the next page.
  */
-export function parseDependentsFromHtml(html: string): Dependent[] {
+export function parseDependentsFromHtml(html: string): {
+  dependents: Dependent[];
+  nextPage: string | null;
+} {
   const dom = new JSDOM(html);
   const div = dom.window.document.getElementById("dependents");
-  if (div !== null) {
-    const box = div.children.item(div.children.length - 2);
-    if (box !== null) {
-      const dependents: Dependent[] = [];
+  if (div === null) throw new Error("invalid HTML format");
 
-      for (let i = 1; i < box.children.length; ++i) {
-        const dependent: Dependent = {
-          repo: null,
-          stars: null,
-          forks: null,
-        };
+  const dependents: Dependent[] = [];
+  let nextPage: string | null = null;
 
-        const row = box.children.item(i);
-        if (row !== null) {
-          dependent.repo = "";
-          const span = row.children.item(1);
-          if (span !== null) {
-            const user = span.children.item(0);
-            if (user !== null) dependent.repo += user.textContent;
-            dependent.repo += "/";
-            const repository = span.children.item(1);
-            if (repository !== null) dependent.repo += repository.textContent;
-          }
+  const box = div.children.item(div.children.length - 2);
+  if (box !== null) {
+    for (let i = 1; i < box.children.length; ++i) {
+      const dependent: Dependent = {
+        repo: null,
+        stars: null,
+        forks: null,
+      };
 
-          const div = row.children.item(2);
-          if (div !== null) {
-            const starsSpan = div.children.item(0);
-            if (starsSpan !== null && starsSpan.textContent !== null) {
-              dependent.stars = Number.parseInt(starsSpan.textContent);
-            }
-
-            const forksSpan = div.children.item(1);
-            if (forksSpan !== null && forksSpan.textContent !== null) {
-              dependent.forks = Number.parseInt(forksSpan.textContent);
-            }
-          }
+      const row = box.children.item(i);
+      if (row !== null) {
+        dependent.repo = "";
+        const span = row.children.item(1);
+        if (span !== null) {
+          const user = span.children.item(0);
+          if (user !== null) dependent.repo += user.textContent;
+          dependent.repo += "/";
+          const repository = span.children.item(1);
+          if (repository !== null) dependent.repo += repository.textContent;
         }
 
-        dependents.push(dependent);
+        const div = row.children.item(2);
+        if (div !== null) {
+          const starsSpan = div.children.item(0);
+          if (starsSpan !== null && starsSpan.textContent !== null) {
+            dependent.stars = Number.parseInt(starsSpan.textContent);
+          }
+
+          const forksSpan = div.children.item(1);
+          if (forksSpan !== null && forksSpan.textContent !== null) {
+            dependent.forks = Number.parseInt(forksSpan.textContent);
+          }
+        }
       }
 
-      return dependents;
+      dependents.push(dependent);
     }
   }
 
-  throw new Error("invalid HTML format");
+  const container = div.children.item(div.children.length - 1);
+  if (container !== null) {
+    const div = container.children.item(0);
+    if (div !== null) {
+      const next = div.children.item(1);
+      if (next !== null) nextPage = next.getAttribute("href");
+    }
+  }
+
+  return { dependents, nextPage };
 }


### PR DESCRIPTION
This pull request resolves #24 primarily by modifying the `fetchDependents` function to fetch dependents from subsequent pages. It also updates `parseDependentsFromHtml` to parse the next page URL and simplify its tests.