### PR TITLE
Add Option to Limit Fetched Dependents

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -11,15 +11,23 @@ yargs(hideBin(process.argv))
     "$0 <repo>",
     "Fetches the dependent repositories of a given repository.",
     (yargs) =>
-      yargs.positional("repo", {
-        demandOption: true,
-        describe:
-          "The full name of the repository in the format `user/repository`",
-        type: "string",
-      }),
+      yargs
+        .positional("repo", {
+          demandOption: true,
+          describe:
+            "The full name of the repository in the format `user/repository`",
+          type: "string",
+        })
+        .option("max-fetch", {
+          describe: "The maximum number of dependent repositories to fetch",
+          type: "number",
+        }),
     async (argv) => {
       try {
-        const dependents = await fetchDependents(argv.repo);
+        const dependents = await fetchDependents(argv.repo, {
+          maxFetch: argv.maxFetch,
+        });
+
         for (const dependent of dependents) {
           const repo: string = dependent.repo ?? "null";
           if (repo.length > 32) {

--- a/src/fetch.test.ts
+++ b/src/fetch.test.ts
@@ -2,7 +2,14 @@ import { fetchDependents } from "./fetch.js";
 
 it("should fetch dependents of a repository", async () => {
   const dependents = await fetchDependents("threeal/setup-yarn-action");
-  expect(dependents.length).toBeGreaterThan(0);
+  expect(dependents.length).toBeGreaterThan(30);
+});
+
+it("should fetch some dependents of a repository", async () => {
+  const dependents = await fetchDependents("threeal/setup-yarn-action", {
+    maxFetch: 5,
+  });
+  expect(dependents.length).toBe(5);
 });
 
 it("should fail to fetch dependents of an invalid repository", async () => {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,13 +1,27 @@
 import { Dependent, parseDependentsFromHtml } from "./parse.js";
 
 /**
+ * Options for fetching dependent repositories.
+ */
+interface FetchDependentsOptions {
+  /**
+   * The maximum number of dependent repositories to fetch.
+   */
+  maxFetch?: number | undefined;
+}
+
+/**
  * Fetches the dependent repositories of a given repository.
  *
  * @param repo - The full name of the repository in the format `user/repository`.
+ * @param options - The options for fetching the dependent repositories.
  * @returns A promise that resolves to a list of dependent repositories.
  * @throws An error if the fetch operation fails.
  */
-export async function fetchDependents(repo: string): Promise<Dependent[]> {
+export async function fetchDependents(
+  repo: string,
+  options?: FetchDependentsOptions,
+): Promise<Dependent[]> {
   const allDependents: Dependent[] = [];
   let url: string | null = `https://github.com/${repo}/network/dependents`;
 
@@ -20,6 +34,15 @@ export async function fetchDependents(repo: string): Promise<Dependent[]> {
     const { dependents, nextPage } = parseDependentsFromHtml(await res.text());
     allDependents.push(...dependents);
     url = nextPage;
+
+    if (
+      options !== undefined &&
+      options.maxFetch !== undefined &&
+      allDependents.length >= options.maxFetch
+    ) {
+      allDependents.splice(options.maxFetch);
+      break;
+    }
   }
 
   return allDependents;


### PR DESCRIPTION
This pull request resolves #26 by updating the `fetchDependents` function to add a new option that allows it to limit the number of dependent repositories fetched. This change also updates the binary script and tests accordingly.