### PR TITLE
Parse Arguments in Binary Script Without Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,15 +32,13 @@
     "test": "jest"
   },
   "dependencies": {
-    "jsdom": "^25.0.1",
-    "yargs": "^17.7.2"
+    "jsdom": "^25.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
     "@types/jest": "^29.5.14",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^22.8.6",
-    "@types/yargs": "^17.0.33",
     "eslint": "^9.13.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.3",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,33 +3,52 @@
 import { fetchDependents } from "./fetch.js";
 import { parseArguments } from "./internal.js";
 
+export const helpMessage = [
+  "github-dependents <repo>",
+  "",
+  "Fetches the dependent repositories of a given repository.",
+  "",
+  "Positionals:",
+  "  repo  The full name of the repository in the format `user/repository` [string]",
+  "",
+  "Options:",
+  "  --help       Show help                                               [boolean]",
+  "  --max-fetch  The maximum number of dependent repositories to fetch    [number]",
+  "",
+].join("\n");
+
 try {
   const args = parseArguments(...process.argv.slice(2));
-  const dependents = await fetchDependents(args.repo, {
-    maxFetch: args.maxFetch,
-  });
+  if (args.help) {
+    process.stdout.write(helpMessage);
+  } else {
+    const dependents = await fetchDependents(args.repo, {
+      maxFetch: args.maxFetch,
+    });
 
-  for (const dependent of dependents) {
-    const repo: string = dependent.repo ?? "null";
-    if (repo.length > 32) {
-      process.stdout.write(`${repo.substring(0, 29)}...`);
-    } else {
-      process.stdout.write(repo.padEnd(32));
+    for (const dependent of dependents) {
+      const repo: string = dependent.repo ?? "null";
+      if (repo.length > 32) {
+        process.stdout.write(`${repo.substring(0, 29)}...`);
+      } else {
+        process.stdout.write(repo.padEnd(32));
+      }
+
+      if (dependent.forks !== null) {
+        const forks = dependent.forks.toString();
+        process.stdout.write(`  ${forks.padStart(3)} forks`);
+      }
+
+      if (dependent.stars !== null) {
+        const stars = dependent.stars.toString();
+        process.stdout.write(`  ${stars.padStart(3)} stars`);
+      }
+
+      process.stdout.write("\n");
     }
-
-    if (dependent.forks !== null) {
-      const forks = dependent.forks.toString();
-      process.stdout.write(`  ${forks.padStart(3)} forks`);
-    }
-
-    if (dependent.stars !== null) {
-      const stars = dependent.stars.toString();
-      process.stdout.write(`  ${stars.padStart(3)} stars`);
-    }
-
-    process.stdout.write("\n");
   }
 } catch (err) {
   process.stderr.write(`${err}\n`);
+  process.stdout.write(`\n${helpMessage}`);
   process.exitCode = 1;
 }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -13,6 +13,7 @@ export const helpMessage = [
   "",
   "Options:",
   "  --help       Show help                                               [boolean]",
+  "  --version    Show version number                                     [boolean]",
   "  --max-fetch  The maximum number of dependent repositories to fetch    [number]",
   "",
 ].join("\n");
@@ -21,6 +22,8 @@ try {
   const args = parseArguments(...process.argv.slice(2));
   if (args.help) {
     process.stdout.write(helpMessage);
+  } else if (args.version) {
+    process.stdout.write("0.1.0\n");
   } else {
     const dependents = await fetchDependents(args.repo, {
       maxFetch: args.maxFetch,

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,57 +1,35 @@
 #!/usr/bin/env node
 
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
 import { fetchDependents } from "./fetch.js";
+import { parseArguments } from "./internal.js";
 
-yargs(hideBin(process.argv))
-  .scriptName("github-dependents")
-  .version("0.1.0")
-  .command(
-    "$0 <repo>",
-    "Fetches the dependent repositories of a given repository.",
-    (yargs) =>
-      yargs
-        .positional("repo", {
-          demandOption: true,
-          describe:
-            "The full name of the repository in the format `user/repository`",
-          type: "string",
-        })
-        .option("max-fetch", {
-          describe: "The maximum number of dependent repositories to fetch",
-          type: "number",
-        }),
-    async (argv) => {
-      try {
-        const dependents = await fetchDependents(argv.repo, {
-          maxFetch: argv.maxFetch,
-        });
+try {
+  const args = parseArguments(...process.argv.slice(2));
+  const dependents = await fetchDependents(args.repo, {
+    maxFetch: args.maxFetch,
+  });
 
-        for (const dependent of dependents) {
-          const repo: string = dependent.repo ?? "null";
-          if (repo.length > 32) {
-            process.stdout.write(`${repo.substring(0, 29)}...`);
-          } else {
-            process.stdout.write(repo.padEnd(32));
-          }
+  for (const dependent of dependents) {
+    const repo: string = dependent.repo ?? "null";
+    if (repo.length > 32) {
+      process.stdout.write(`${repo.substring(0, 29)}...`);
+    } else {
+      process.stdout.write(repo.padEnd(32));
+    }
 
-          if (dependent.forks !== null) {
-            const forks = dependent.forks.toString();
-            process.stdout.write(`  ${forks.padStart(3)} forks`);
-          }
+    if (dependent.forks !== null) {
+      const forks = dependent.forks.toString();
+      process.stdout.write(`  ${forks.padStart(3)} forks`);
+    }
 
-          if (dependent.stars !== null) {
-            const stars = dependent.stars.toString();
-            process.stdout.write(`  ${stars.padStart(3)} stars`);
-          }
+    if (dependent.stars !== null) {
+      const stars = dependent.stars.toString();
+      process.stdout.write(`  ${stars.padStart(3)} stars`);
+    }
 
-          process.stdout.write("\n");
-        }
-      } catch (err) {
-        process.stdout.write(`${err}\n`);
-        process.exitCode = 1;
-      }
-    },
-  )
-  .parse();
+    process.stdout.write("\n");
+  }
+} catch (err) {
+  process.stderr.write(`${err}\n`);
+  process.exitCode = 1;
+}

--- a/src/internal.test.ts
+++ b/src/internal.test.ts
@@ -1,20 +1,26 @@
 import { parseArguments } from "./internal";
 
 it("should parse arguments", () => {
-  expect(parseArguments("--max-fetch", "8", "a-repo")).toEqual({
+  expect(parseArguments("a-repo", "--max-fetch", "8")).toEqual({
     repo: "a-repo",
+    help: false,
     maxFetch: 8,
   });
 });
 
+it("should parse the help argument", () => {
+  expect(parseArguments("--help")).toEqual({
+    repo: "",
+    help: true,
+  });
+});
+
 it("should fail to parse arguments due to a missing max fetch value", () => {
-  expect(() => parseArguments("--max-fetch")).toThrow(
+  expect(() => parseArguments("a-repo", "--max-fetch")).toThrow(
     "Missing value for the `--max-fetch` option",
   );
 });
 
 it("should fail to parse arguments due to a missing repo argument", () => {
-  expect(() => parseArguments("--max-fetch", "a-repo")).toThrow(
-    "Missing 'repo' argument",
-  );
+  expect(() => parseArguments()).toThrow("Missing 'repo' argument");
 });

--- a/src/internal.test.ts
+++ b/src/internal.test.ts
@@ -1,0 +1,20 @@
+import { parseArguments } from "./internal";
+
+it("should parse arguments", () => {
+  expect(parseArguments("--max-fetch", "8", "a-repo")).toEqual({
+    repo: "a-repo",
+    maxFetch: 8,
+  });
+});
+
+it("should fail to parse arguments due to a missing max fetch value", () => {
+  expect(() => parseArguments("--max-fetch")).toThrow(
+    "Missing value for the `--max-fetch` option",
+  );
+});
+
+it("should fail to parse arguments due to a missing repo argument", () => {
+  expect(() => parseArguments("--max-fetch", "a-repo")).toThrow(
+    "Missing 'repo' argument",
+  );
+});

--- a/src/internal.test.ts
+++ b/src/internal.test.ts
@@ -4,6 +4,7 @@ it("should parse arguments", () => {
   expect(parseArguments("a-repo", "--max-fetch", "8")).toEqual({
     repo: "a-repo",
     help: false,
+    version: false,
     maxFetch: 8,
   });
 });
@@ -12,6 +13,15 @@ it("should parse the help argument", () => {
   expect(parseArguments("--help")).toEqual({
     repo: "",
     help: true,
+    version: false,
+  });
+});
+
+it("should parse the version argument", () => {
+  expect(parseArguments("--version")).toEqual({
+    repo: "",
+    help: false,
+    version: true,
   });
 });
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -4,6 +4,7 @@
  */
 export interface Arguments {
   repo: string;
+  help: boolean;
   maxFetch?: number | undefined;
 }
 
@@ -21,7 +22,9 @@ export function parseArguments(...argv: string[]): Arguments {
 
   while (argv.length > 0) {
     const arg = argv.shift();
-    if (arg === "--max-fetch") {
+    if (arg === "-h" || arg === "--help") {
+      return { repo: "", help: true };
+    } else if (arg === "--max-fetch") {
       const arg = argv.shift();
       if (arg === undefined) {
         throw new Error("Missing value for the `--max-fetch` option");
@@ -36,5 +39,5 @@ export function parseArguments(...argv: string[]): Arguments {
     throw new Error("Missing 'repo' argument");
   }
 
-  return { repo, maxFetch };
+  return { repo, help: false, maxFetch };
 }

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,0 +1,40 @@
+/**
+ * @internal
+ * Represents parsed arguments.
+ */
+export interface Arguments {
+  repo: string;
+  maxFetch?: number | undefined;
+}
+
+/**
+ * @internal
+ * Parses command-line arguments into an Arguments object.
+ *
+ * @param argv - The command-line arguments to parse.
+ * @returns An Arguments object containing the parsed values.
+ * @throws An error if required arguments are missing or invalid.
+ */
+export function parseArguments(...argv: string[]): Arguments {
+  let repo: string | undefined;
+  let maxFetch: number | undefined;
+
+  while (argv.length > 0) {
+    const arg = argv.shift();
+    if (arg === "--max-fetch") {
+      const arg = argv.shift();
+      if (arg === undefined) {
+        throw new Error("Missing value for the `--max-fetch` option");
+      }
+      maxFetch = parseInt(arg);
+    } else if (repo === undefined) {
+      repo = arg;
+    }
+  }
+
+  if (repo === undefined) {
+    throw new Error("Missing 'repo' argument");
+  }
+
+  return { repo, maxFetch };
+}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -5,6 +5,7 @@
 export interface Arguments {
   repo: string;
   help: boolean;
+  version: boolean;
   maxFetch?: number | undefined;
 }
 
@@ -23,7 +24,9 @@ export function parseArguments(...argv: string[]): Arguments {
   while (argv.length > 0) {
     const arg = argv.shift();
     if (arg === "-h" || arg === "--help") {
-      return { repo: "", help: true };
+      return { repo: "", help: true, version: false };
+    } else if (arg === "-v" || arg === "--version") {
+      return { repo: "", help: false, version: true };
     } else if (arg === "--max-fetch") {
       const arg = argv.shift();
       if (arg === undefined) {
@@ -39,5 +42,5 @@ export function parseArguments(...argv: string[]): Arguments {
     throw new Error("Missing 'repo' argument");
   }
 
-  return { repo, help: false, maxFetch };
+  return { repo, help: false, version: false, maxFetch };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,15 +1290,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.33":
-  version: 17.0.33
-  resolution: "@types/yargs@npm:17.0.33"
-  dependencies:
-    "@types/yargs-parser": "npm:*"
-  checksum: 10c0/d16937d7ac30dff697801c3d6f235be2166df42e4a88bf730fa6dc09201de3727c0a9500c59a672122313341de5f24e45ee0ff579c08ce91928e519090b7906b
-  languageName: node
-  linkType: hard
-
 "@types/yargs@npm:^17.0.8":
   version: 17.0.24
   resolution: "@types/yargs@npm:17.0.24"
@@ -2705,7 +2696,6 @@ __metadata:
     "@types/jest": "npm:^29.5.14"
     "@types/jsdom": "npm:^21.1.7"
     "@types/node": "npm:^22.8.6"
-    "@types/yargs": "npm:^17.0.33"
     eslint: "npm:^9.13.0"
     jest: "npm:^29.7.0"
     jsdom: "npm:^25.0.1"
@@ -2714,7 +2704,6 @@ __metadata:
     typedoc: "npm:^0.26.11"
     typescript: "npm:^5.6.3"
     typescript-eslint: "npm:^8.12.2"
-    yargs: "npm:^17.7.2"
   bin:
     github-dependents: dist/bin.js
   languageName: unknown
@@ -5578,7 +5567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.3.1, yargs@npm:^17.7.2":
+"yargs@npm:^17.3.1":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
This pull request resolves #30 by modifying the binary script in the `src/bin.ts` file to parse arguments without using yargs. Instead, it introduces a new `parseArguments` function for handling argument parsing, minimizing dependencies for this project.