### PR TITLE
Bump Yarn to Version 4.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,5 @@
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.14.0"
   },
-  "packageManager": "yarn@4.5.1"
+  "packageManager": "yarn@4.5.2"
 }


### PR DESCRIPTION
This pull request simply bumps Yarn to version [4.5.2](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.5.2).