### PR TITLE
Separate TypeScript Build Configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
         run: pnpm eslint
 
       - name: Check Types
-        run: pnpm tsc --noEmit
+        run: pnpm tsc
 
       - name: Check Documentation
         run: pnpm typedoc src/index.ts --emit none --treatWarningsAsErrors

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,14 +15,12 @@ pre-commit:
       run: pnpm eslint --no-warn-ignored --fix {staged_files}
 
     - name: check types
-      run: pnpm tsc --noEmit
+      run: pnpm tsc
       glob:
-        - src/*.ts
+        - "*.ts"
         - .npmrc
         - pnpm-lock.yaml
         - tsconfig.json
-      exclude:
-        - src/*.test.ts
 
     - name: check documentation
       run: pnpm typedoc src/index.ts --emit none --treatWarningsAsErrors

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "dist"
   ],
   "scripts": {
-    "prepack": "tsc",
+    "prepack": "tsc -p tsconfig.build.json",
     "test": "vitest run"
   },
   "dependencies": {

--- a/src/internal.test.ts
+++ b/src/internal.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { parseArguments } from "./internal";
+import { parseArguments } from "./internal.js";
 
 it("should parse arguments", () => {
   expect(parseArguments("a-repo", "--max-fetch", "8")).toEqual({

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/node24",
+  "include": ["src"],
+  "exclude": ["**/*.test.*"],
+  "compilerOptions": {
+    "declaration": true,
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "extends": "@tsconfig/node24",
-  "include": ["src"],
-  "exclude": ["**/*.test.*"],
   "compilerOptions": {
-    "declaration": true,
-    "outDir": "dist"
+    "noEmit": true
   }
 }


### PR DESCRIPTION
This pull request resolves #242 by separating the TypeScript configurations into `tsconfig.json` for type checking and `tsconfig.build.json` for building the library.