### PR TITLE
Lock pnpm to version 10.33.4 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
+        with:
+          version: 10.33.4
 
       - name: Install Dependencies
         run: pnpm install


### PR DESCRIPTION
## Summary

- Applies the same pnpm version lock (`10.33.4`) to the deploy workflow that was applied to the build workflow in #472
- Adds `version: 10.33.4` to the `Setup pnpm` step in `.github/workflows/deploy.yaml`

## Test plan

- [ ] Verify the Deploy workflow runs successfully on merge to `main`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)